### PR TITLE
Name typo fix

### DIFF
--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -63,7 +63,7 @@
 			<p>“What finally happened?”</p>
 			<p>“Oh, someone took her home. Not a bad-looking girl. Wonderful command of the idiom. Do stay and have a drink.”</p>
 			<p>“No,” I said. “I must shove off. Seen Cohn?”</p>
-			<p>“He went home with Frances,” <abbr epub:type="z3998:name-title">Mrs.</abbr> Braddock put in.</p>
+			<p>“He went home with Frances,” <abbr epub:type="z3998:name-title">Mrs.</abbr> Braddocks put in.</p>
 			<p>“Poor chap, he looks awfully down,” Braddocks said.</p>
 			<p>“I dare say he is,” said <abbr epub:type="z3998:name-title">Mrs.</abbr> Braddocks.</p>
 			<p>“I have to shove off,” I said. “Good night.”</p>


### PR DESCRIPTION
Changing "Braddock" to "Braddocks" to be consistent with the other uses of that name.